### PR TITLE
[DEL] deprecated parameter "vpc"

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -189,12 +189,12 @@ resource "aws_subnet" "private_2" {
 # A NAT gateway is required for the private subnet.
 # Configure EIP for the first NAT Gateway.
 resource "aws_eip" "nat_1" {
-  vpc = true
+  domain = "vpc"
 }
 
 # configure EIP for the second NAT gateway.
 resource "aws_eip" "nat_2" {
-  vpc = true
+  domain = "vpc"
 }
 
 # Create the first NAT gateway.


### PR DESCRIPTION
Delete deprecated parameter "vpc" from "aws_eip". 

*Issue #, if available:*

```
$ terraform validate

Warning: Argument is deprecated

  with aws_eip.nat_1,
  on main.tf line 192, in resource "aws_eip" "nat_1":
 192:   vpc = true

use domain attribute instead
```


*Description of changes:*

Use of "domain" parameter instead for "aws_eip"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
